### PR TITLE
Enable usage in mobile devices

### DIFF
--- a/block_jmail.php
+++ b/block_jmail.php
@@ -1,6 +1,6 @@
 <?php
 // This file is part of Moodle - http://moodle.org/
-//
+// 
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/module.js
+++ b/module.js
@@ -63,22 +63,38 @@ M.block_jmail.init = function(Y, cfg) {
     }
 
     Y.one('#newemailpanel').setStyle('display', 'block');
-    var panel = new YAHOO.widget.Panel("newemailpanel", {
-        draggable: true,
-        modal: false,
-        width: "800px",
-        height: panelHeight,
-        autofillheight: "body",
-        visible: false,
-        zindex:2,
-        top: "50px",
-        context: ['jmailui', 'tl', 'tl', null, [200, 0]]
-    });
+    var resWidth = Y.one('document').get('winWidth');
+    M.block_jmail.logInfo('Window width:'+resWidth);
+    var panel = null
+    if ( resWidth>= 960) {
+	M.block_jmail.logInfo('Loading Panel Config');
+	        panel = new YAHOO.widget.Panel("newemailpanel", {
+		draggable: true,
+		modal: false,
+		width: "800px",
+		height: panelHeight,
+		autofillheight: "body",
+		visible: false,
+		zindex:2,
+		top: "50px",
+		context: ['jmailui', 'tl', 'tl', null, [200, 0]]
+	    });
+	 panel.render(document.body);
+    }
+    else {
+	M.block_jmail.logInfo('Loading Module Config');
+	panel = new YAHOO.widget.Module("newemailpanel", {
+		visible: false,
+		context: ['jmailui', 'tl', 'tl', null, [200, 0]]
+	    });
+	 panel.render(Y.one('#jmailleft #action_buttons'),document.body);
+    }
+    
 
     panel.subscribe("hide", function (event) {
         M.block_jmail.newemailOpen = false;
     });
-    panel.render(document.body);
+    //panel.render(Y.one('#jmailleft #actionbuttons'),document.body);
     M.block_jmail.app.composePanel = panel;
 
     //var fptpl = Y.one("#filepickertpl");

--- a/styles.css
+++ b/styles.css
@@ -252,3 +252,84 @@
 .composelist {
     display: inline;
 }
+
+/* Clear for low resolutions*/
+
+@media (max-width:959px) {
+	
+	
+
+	#jmailui, 
+	#jmailui .yui-layout, 
+	#jmailui .yui-layout-wrap,
+	#jmailui .yui-layout-resize, 
+	#jmailui .yui-layout-unit, 
+	#jmailui .yui-layout-bd,
+	#jmailui .yui-layout-doc{
+		position:initial !important;
+		height:auto !important;
+		width:auto !important;
+	}
+/*
+	#jmailui, #jmailui div {
+		height:auto !important;
+		width:auto !important;
+		/*float:none !important;	*/
+	/*}*/
+
+	#jmailui .yui-resize-handle {
+		display:none;	
+	}
+
+	#jmailui #contact_list_users {
+		height:150px !important;
+		overflow-y:auto;	
+	}
+
+	#mailarea, #mailarea table {
+		width:100% !important;
+	}
+
+	#mailarea .yui-dt-bd,
+	#mailarea .yui-dt-hd {
+		width:100% !important;
+	}
+
+        #newemailpanel {
+		clear:both;	
+	}
+
+	#newemailform #fitem_id_attachments{
+		display:none;
+	}
+
+	#newemailform .fitemtitle {
+		float:left;	
+		width:auto !important;
+	}
+		
+	#newemailform .fitemtitle label {
+		width: 70px !important;	
+	}
+
+	
+	#newemailpanel .hd {
+		display:none;	
+	}
+	
+	
+	#newemailform.mform .fitem .felement {
+	    border-width: 0;
+	    margin-left: 11%;
+	    width: 80%;
+	}
+
+	#newemailform .felement.feditor iframe {
+		max-height:none !important;	
+	}
+	
+	#mymailboxes .yui-module.yui-overlay.yuimenu.yui-button-menu.yui-menu-button-menu {
+		position:absolute !important;	
+	}
+	
+}


### PR DESCRIPTION
Hello,

currently Jmail is unusable on mobile devices. We have made a modification to enable usage on phones and tablets. 

Tested on Google Chrome and Firefox for Android.
